### PR TITLE
toolbox: add support for multi-layered docker images

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -52,20 +52,19 @@ if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 
 	if [[ -n "${have_docker_image}" ]]; then
 		sudo --preserve-env docker pull "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"
-		diid=$(sudo --preserve-env docker images --filter=reference=${TOOLBOX_DOCKER_IMAGE} --format "{{.ID}}")
-		sudo --preserve-env docker save --output=${diid}.tar.gz "${diid}"
-		sudo --preserve-env tar xvf ${diid}.tar.gz -C "${machinepath}"
-		for layer_tarball in $(jq -r '.[].Layers[]' ${machinepath}/manifest.json); do
-			sudo --preserve-env tar xvf ${machinepath}/${layer_tarball} -C "${machinepath}"
-			sudo --preserve-env rm -f ${machinepath}/${layer_tarball}
-		done
-		sudo --preserve-env docker rmi "${diid}"
+		dcid=$(sudo --preserve-env docker create "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
+		sudo --preserve-env docker export -o "${machinepath}/${dcid}.tar" ${dcid}
+		sudo --preserve-env docker rm ${dcid}
+		sudo --preserve-env docker rmi "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}" || true
+		sudo tar xvf "${machinepath}/${dcid}.tar" -C "${machinepath}"
+		sudo rm -f "${machinepath}/${dcid}.tar"
 	elif [[ -n "${TOOLBOX_DOCKER_ARCHIVE}" ]]; then
 		tmpdir=$(mktemp -d -p /var/tmp/)
 		trap "sudo rm -rf ${tmpdir}" EXIT PIPE
 		wget -O- "${TOOLBOX_DOCKER_ARCHIVE}" | xz -cd | tar -C ${tmpdir} -xf -
-		layer=$(find ${tmpdir} -name layer.tar -type f)
-		sudo tar -C ${machinepath} -xf ${layer}
+		for layer in $(jq -r '.[].Layers[]' ${tmpdir}/manifest.json); do
+			sudo tar xvf "${tmpdir}/${layer}" -C "${machinepath}"
+		done
 		trap - EXIT PIPE
 		sudo rm -rf ${tmpdir}
 	else

--- a/toolbox
+++ b/toolbox
@@ -40,7 +40,9 @@ fi
 
 if [[ -n "${TOOLBOX_DOCKER_IMAGE}" ]] && [[ -n "${TOOLBOX_DOCKER_TAG}" ]]; then
 	TOOLBOX_NAME=${TOOLBOX_DOCKER_IMAGE}-${TOOLBOX_DOCKER_TAG}
-	have_docker_image="y"
+else
+	echo "Error: Invalid Docker image name: '${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}'" >&2
+	exit 1
 fi
 
 machinename=$(echo "${USER}-${TOOLBOX_NAME}" | sed -r 's/[^a-zA-Z0-9_.-]/_/g')
@@ -50,27 +52,15 @@ if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 	sudo mkdir -p "${machinepath}"
 	sudo chown "${USER}:" "${machinepath}"
 
-	if [[ -n "${have_docker_image}" ]]; then
-		sudo --preserve-env docker pull "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"
-		dcid=$(sudo --preserve-env docker create "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
-		sudo --preserve-env docker export -o "${machinepath}/${dcid}.tar" ${dcid}
-		sudo --preserve-env docker rm ${dcid}
-		sudo --preserve-env docker rmi "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}" || true
-		sudo tar xvf "${machinepath}/${dcid}.tar" -C "${machinepath}"
-		sudo rm -f "${machinepath}/${dcid}.tar"
-	elif [[ -n "${TOOLBOX_DOCKER_ARCHIVE}" ]]; then
-		tmpdir=$(mktemp -d -p /var/tmp/)
-		trap "sudo rm -rf ${tmpdir}" EXIT PIPE
-		wget -O- "${TOOLBOX_DOCKER_ARCHIVE}" | xz -cd | tar -C ${tmpdir} -xf -
-		for layer in $(jq -r '.[].Layers[]' ${tmpdir}/manifest.json); do
-			sudo tar xvf "${tmpdir}/${layer}" -C "${machinepath}"
-		done
-		trap - EXIT PIPE
-		sudo rm -rf ${tmpdir}
-	else
-		echo "Error: No toolbox filesystem specified." >&2
-		exit 1
-	fi
+	# Download and extract the image.
+	sudo --preserve-env docker pull "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"
+	dcid=$(sudo --preserve-env docker create "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
+	sudo --preserve-env docker export -o "${machinepath}/${dcid}.tar" ${dcid}
+	sudo --preserve-env docker rm ${dcid}
+	sudo --preserve-env docker rmi "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}" || true
+	sudo tar xvf "${machinepath}/${dcid}.tar" -C "${machinepath}"
+	sudo rm -f "${machinepath}/${dcid}.tar"
+
 	sudo touch "${osrelease}"
 fi
 

--- a/toolbox
+++ b/toolbox
@@ -55,9 +55,10 @@ if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 		diid=$(sudo --preserve-env docker images --filter=reference=${TOOLBOX_DOCKER_IMAGE} --format "{{.ID}}")
 		sudo --preserve-env docker save --output=${diid}.tar.gz "${diid}"
 		sudo --preserve-env tar xvf ${diid}.tar.gz -C "${machinepath}"
-		layer_tarball=$(cat ${machinepath}/manifest.json | jq -r '.[].Layers[]')
-		sudo --preserve-env tar xvf ${machinepath}/${layer_tarball} -C "${machinepath}"
-		sudo --preserve-env rm -f ${machinepath}/${layer_tarball}
+		for layer_tarball in $(jq -r '.[].Layers[]' ${machinepath}/manifest.json); do
+			sudo --preserve-env tar xvf ${machinepath}/${layer_tarball} -C "${machinepath}"
+			sudo --preserve-env rm -f ${machinepath}/${layer_tarball}
+		done
 		sudo --preserve-env docker rmi "${diid}"
 	elif [[ -n "${TOOLBOX_DOCKER_ARCHIVE}" ]]; then
 		tmpdir=$(mktemp -d -p /var/tmp/)


### PR DESCRIPTION
# Handle multi-layered Docker images correctly

This is intended to fix https://github.com/flatcar-linux/Flatcar/issues/465 and https://github.com/flatcar-linux/Flatcar/issues/508

Currently, `toolbox` assumes all Docker images are made of 1 layer : it puts the name of the layer tarball in a variable and passes it to `tar`. This fails if the images has multiple layers, as the variable contains several filenames.

This patch simply adds a for loop to extract each layer in sequence.

## How to use

Run toolbox with a multi-layered docker image, like `ubuntu-debootstrap:14.04`.

## Testing done

```shell
$ cat .toolboxrc
TOOLBOX_DOCKER_IMAGE=ubuntu-debootstrap
TOOLBOX_DOCKER_TAG=14.04
$ toolbox
14.04: Pulling from library/ubuntu-debootstrap
Image docker.io/library/ubuntu-debootstrap:14.04 uses outdated schema1 manifest format. Please upgrade to a schema2 image for better future compatibility. More information at https://docs.docker.com/registry/spec/deprecated-schema-v1/
c02c7df4a131: Pull complete 
a3ed95caeb02: Pull complete 
Digest: sha256:b424724203198bdb60d79368bf967c71534dd25f2b7703021110f04e1a81b78c
Status: Downloaded newer image for ubuntu-debootstrap:14.04
docker.io/library/ubuntu-debootstrap:14.04
0539e3ca23a9804b912d4c7fd9d71acd4f4303648056c8817dff756216a8e474/
0539e3ca23a9804b912d4c7fd9d71acd4f4303648056c8817dff756216a8e474/VERSION
0539e3ca23a9804b912d4c7fd9d71acd4f4303648056c8817dff756216a8e474/json
0539e3ca23a9804b912d4c7fd9d71acd4f4303648056c8817dff756216a8e474/layer.tar
898cb62b73684611dcb1f478fa1731683cabc30ddbdc692b0fb027b69cec1033.json
d78a692d1a017b78c77045caff969c337a9e5f83cc1309efbab2c0c982c1ac12/
d78a692d1a017b78c77045caff969c337a9e5f83cc1309efbab2c0c982c1ac12/VERSION
d78a692d1a017b78c77045caff969c337a9e5f83cc1309efbab2c0c982c1ac12/json
d78a692d1a017b78c77045caff969c337a9e5f83cc1309efbab2c0c982c1ac12/layer.tar
manifest.json
...
Untagged: ubuntu-debootstrap:14.04
Untagged: ubuntu-debootstrap@sha256:b424724203198bdb60d79368bf967c71534dd25f2b7703021110f04e1a81b78c
Deleted: sha256:898cb62b73684611dcb1f478fa1731683cabc30ddbdc692b0fb027b69cec1033
Deleted: sha256:c05c8727aa340e50ec560afe8159ced1e88a461579d51fcde5b91f9e918817a6
Deleted: sha256:45befd8a8901eecc964f2c766a93cb8f0f49752a31db8db3af854798f75ebf8e
Spawning container odc-ubuntu-debootstrap-14.04 on /var/lib/toolbox/odc-ubuntu-debootstrap-14.04.
Press ^] three times within 1s to kill container.
root@ip-10-188-70-239:~#
```