### PR TITLE
feat(toolbox-ctr): script using ctr instead of docker

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -6,19 +6,29 @@ set -o pipefail
 machine=$(uname -m)
 
 case ${machine} in
-	aarch64 )
-		TOOLBOX_DOCKER_IMAGE=arm64v8/fedora
-		TOOLBOX_DOCKER_TAG=latest
+	arm)
+		PLATFORM=linux/arm
 		;;
-	x86_64 )
-		TOOLBOX_DOCKER_IMAGE=fedora
-		TOOLBOX_DOCKER_TAG=latest
+	aarch64)
+		PLATFORM=linux/arm64
 		;;
-	* )
+	riscv64)
+		PLATFORM=linux/riscv64
+		;;
+	x86)
+		PLATFORM=linux/386
+		;;
+	x86_64)
+		PLATFORM=linux/amd64
+		;;
+	*)
 		echo "Warning: Unknown machine type ${machine}" >&2
+		exit 1
 		;;
 esac
 
+TOOLBOX_DOCKER_IMAGE=docker.io/library/fedora
+TOOLBOX_DOCKER_TAG=latest
 TOOLBOX_USER=root
 TOOLBOX_DIRECTORY="/var/lib/toolbox"
 TOOLBOX_BIND="--bind=/:/media/root --bind=/usr:/media/root/usr --bind=/run:/media/root/run --bind=/sys/fs/bpf:/sys/fs/bpf"
@@ -48,18 +58,30 @@ fi
 machinename=$(echo "${USER}-${TOOLBOX_NAME}" | sed -r 's/[^a-zA-Z0-9_.-]/_/g')
 machinepath="${TOOLBOX_DIRECTORY}/${machinename}"
 osrelease="${machinepath}/etc/os-release"
+
 if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 	sudo mkdir -p "${machinepath}"
 	sudo chown "${USER}:" "${machinepath}"
 
-	# Download and extract the image.
-	sudo --preserve-env docker pull "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"
-	dcid=$(sudo --preserve-env docker create "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
-	sudo --preserve-env docker export -o "${machinepath}/${dcid}.tar" ${dcid}
-	sudo --preserve-env docker rm ${dcid}
-	sudo --preserve-env docker rmi "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}" || true
-	sudo tar xvf "${machinepath}/${dcid}.tar" -C "${machinepath}"
-	sudo rm -f "${machinepath}/${dcid}.tar"
+	if sudo -E ctr version &> /dev/null; then
+		# Check if we already got our image, do not overwrite
+		if ! sudo -E ctr images check | grep "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"; then
+			sudo -E ctr images pull --platform ${PLATFORM} ${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}
+		fi
+		sudo ctr images mount --rw --platform ${PLATFORM} ${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG} ${machinepath}
+	elif sudo -E docker stats --no-stream &> /dev/null; then
+		# Download and extract the image.
+		sudo --preserve-env docker pull "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"
+		dcid=$(sudo --preserve-env docker create "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
+		sudo --preserve-env docker export -o "${machinepath}/${dcid}.tar" ${dcid}
+		sudo --preserve-env docker rm ${dcid}
+		sudo --preserve-env docker rmi "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}" || true
+		sudo tar xvf "${machinepath}/${dcid}.tar" -C "${machinepath}"
+		sudo rm -f "${machinepath}/${dcid}.tar"
+	else
+		echo "No supported container runtime found." >&2
+		exit 2
+	fi
 
 	sudo touch "${osrelease}"
 fi


### PR DESCRIPTION
# [Toolbox version using ctr]

Toolbox version using ctr cli instead of docker for system which have only containerd and not docker daemon.

Use debian:unstable-slim image as default.

## How to use

Just type `toolbox-ctr` (as root) on a flatcar running containerd.

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
