### PR TITLE
toolbox: prevent mounted snapshots from being gc'ed

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -68,7 +68,8 @@ if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 		if ! sudo -E ctr images check | grep "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"; then
 			sudo -E ctr images pull --platform ${PLATFORM} ${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}
 		fi
-		sudo ctr images mount --rw --platform ${PLATFORM} ${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG} ${machinepath}
+		sudo ctr images mount --rw --platform ${PLATFORM} ${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG} "${machinepath}"
+		sudo ctr snapshots label "${machinepath}" containerd.io/gc.root=true
 	elif sudo -E docker stats --no-stream &> /dev/null; then
 		# Download and extract the image.
 		sudo --preserve-env docker pull "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"


### PR DESCRIPTION
The toolbox uses ctr under the hood if available. The 'ctr image mount' command by default adds a 1 day lease on the created snapshot that is mounted as the upperdir. Therfore the snapshot will be gc'ed and the toolbox not function correctly anymore as the upperdir does not longer exist.

# mounted upperdir snapshot is gc'ed after lease times out

The toolbox script uses the ctr client (which it seems should only be used for testing and administrative purposes?). This client will create a lease when using the `ctr image mount` command which lasts for one day and references the rw snapshot created. 

When said lease expires it will remove the upperdir of the mount and make the toolbox somewhat none functional.

In detail, if we run toolbox it will mount the fedore image and a rw snapshot which can be seen here:
```bash
$ cat /proc/mounts | grep toolbox
overlay /var/lib/toolbox/core-docker.io_library_fedora-38 overlay rw,seclabel,relatime,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/1/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/27/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/27/work,uuid=on 0 0
```

When inspecting the leases with ctr we can see that it creates a lease valid for a day:
```bash
$ sudo ctr leases ls
ID                                                CREATED AT           LABELS                                                                                                                                 
/var/lib/toolbox/core-docker.io_library_fedora-38 2024-03-12T15:38:53Z containerd.io/gc.expire=2024-03-13T15:38:53Z,containerd.io/gc.ref.snapshot.overlayfs=/var/lib/toolbox/core-docker.io_library_fedora-38 
```

After the lease expires it will remove the snapshot and therefore the mounted upperdir.

This lease can't be changed as it seems hardcoded in the client https://github.com/containerd/containerd/blob/main/cmd/ctr/commands/images/mount.go#L76-L80.

I worked around this by manually setting the label [containerd.io/gc.root=true](https://github.com/containerd/containerd/blob/main/docs/garbage-collection.md#garbage-collection-labels) on the snapshot. This will prevent the 
GC from removing the snapshot

```bash
$ sudo ctr snapshots info /var/lib/toolbox/core-docker.io_library_fedora-38
{
    "Kind": "Active",
    "Name": "/var/lib/toolbox/core-docker.io_library_fedora-38",
    "Parent": "sha256:fdc6e90d218ce752383b418a061d823f1dd876cab4514aa86ca02811498f60f4",
    "Labels": {
        "containerd.io/gc.root": "true"
    },
    "Created": "2024-03-12T15:38:53.586782845Z",
    "Updated": "2024-03-12T15:38:53.633095228Z"
}

```

There is also a --label flag which does not seem to work.


I'm not sure if setting `containerd.io/gc.root` is the best solution or if there is something else since i don't 100% understand what containerd is doing.

For testing purposes i built an own version of ctr which sets the lease time to 1 minute. This helped for testing the problem.

## How to use

Run the toolbox command on flatcar as usual and inspect manually with `ctr leases ls`, `ctr snapshots ls` and `ctr snapshots info`.

## Testing done

Copied the toolbox script and updated it according to this PR. Called directly instead of the provided toolbox script.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
