### PR TITLE
feat: podman support

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -79,6 +79,18 @@ if [ ! -f "${osrelease}" ] || systemctl is-failed -q "${machinename}" ; then
 		sudo --preserve-env docker rmi "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}" || true
 		sudo tar xvf "${machinepath}/${dcid}.tar" -C "${machinepath}"
 		sudo rm -f "${machinepath}/${dcid}.tar"
+	elif sudo -E podman version &> /dev/null; then
+		is_downloaded=false
+		if ! sudo -E podman image exists "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"; then
+			sudo -E podman pull "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"
+			is_downloaded=true
+		fi
+		imgpath=$(sudo -E podman image mount "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}")
+		sudo cp -af "${imgpath}/." "${machinepath}"
+		sudo -E podman image umount "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"
+		if "${is_downloaded}" ; then
+			sudo -E podman image rm "${TOOLBOX_DOCKER_IMAGE}:${TOOLBOX_DOCKER_TAG}"
+		fi
 	else
 		echo "No supported container runtime found." >&2
 		exit 2


### PR DESCRIPTION
# podman support

Fallback to podman if docker and containerd don't exist.

Related to https://github.com/flatcar/Flatcar/issues/1778

## How to use

- [Enable podman](https://www.flatcar.org/docs/latest/provisioning/sysext/#flatcar-release-extensions-official)
- [Disable docker and containerd](https://www.flatcar.org/docs/latest/provisioning/sysext/#remove-docker-and--or-containerd-from-flatcar)
- run toolbox

## Testing done

* ran toolbox in flatcar environment with podman and without docker/containerd

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
